### PR TITLE
Fix typo in train.py: Correct UNe t_baseline to UNet_baseline

### DIFF
--- a/Diffusion_UKAN/Diffusion/Train.py
+++ b/Diffusion_UKAN/Diffusion/Train.py
@@ -9,7 +9,7 @@ from torchvision import transforms, transforms
 # from torchvision.datasets import CIFAR10
 from torchvision.utils import save_image
 from Diffusion import GaussianDiffusionSampler, GaussianDiffusionTrainer
-from Diffusion.UNet import UNet, UNe    t_Baseline
+from Diffusion.UNet import UNet, UNet_Baseline
 from Diffusion.Model_ConvKan import UNet_ConvKan
 from Diffusion.Model_UMLP import UMLP
 from Diffusion.Model_UKAN_Hybrid import UKan_Hybrid


### PR DESCRIPTION
This PR corrects a small typo in the train.py file where UNe  t_baseline was written instead of UNet_baseline. 